### PR TITLE
Fix the Auth system

### DIFF
--- a/ui/web/src/utils/authUtils.js
+++ b/ui/web/src/utils/authUtils.js
@@ -6,7 +6,8 @@ const userPool = {
 
 export function getLoginUrl() {
   const url = new URL(window.location)
-  const authRedirect = `${url.origin}/auth?redirect_url=${encodeURIComponent(url.pathname + url.search)}`
+//  const authRedirect = `${url.origin}/auth?redirect_url=${encodeURIComponent(url.pathname + url.search)}`
+  const authRedirect = `${url.origin}/auth`
   return `https://auth.build360.io/login?client_id=${userPool.ClientId}&response_type=token&scope=email+openid+phone+profile&redirect_uri=${authRedirect}`
 }
 


### PR DESCRIPTION
I think we cannot use passthrough arguements with the redirect.  I'll try and run it down.  If you approve this PR, check to see if it works.  I set dev.build360.io/auth as an allowed redirect value.